### PR TITLE
Support v0.10.* and v0.12.* versions of Node.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,9 @@
 node_modules/
-build/
 .idea/
 .DS_Store
 *npm-debug.log
+log/
+*.swp
+*.swo
+coverage/
+plato/

--- a/.npmignore
+++ b/.npmignore
@@ -1,4 +1,7 @@
 demo/
 tmp/
 node_modules/
-build/
+log/
+spec/
+plato/
+coverage/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,8 @@
+## Changelog
+
+## 0.1.*
+
+### 0.1.0
+
+ * Update to basejump version that supports Node versions v0.10.* and v0.12.*
+ * Update to use MAC or Machine and PID as default worker id to ensure uniqueness

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2014 LeanKit
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -7,10 +7,22 @@ I didn't see any existing Node solutions for Boundary's Flake or Twitter's Snowf
  * Lexicographically sortable
  * Coordination free-ish
 
+### Break down
+128 bit key comprised of the following:
+
+`{timestamp}{worker}{sequence}`
+
+ * 64 bit timestamp
+ * 48 bit worker id
+ * 16 bit sequence number
+
+The sequence number increments for each subsequent id requested within the same millisecond.
+
 ## API
 
-### Using MACAddress as seed
-If no seed is provided during start-up, sliver will attempt to create a seed from the MACAddress. While this is great, it also means that you can't have two processes using sliver independently and still guarantee unique ids (a bad thing).
+### Using MACAddress or HostName as seed
+If no seed is provided, Sliver will use either the MAC address or host name plus the process id as the seed. This should prevent duplicate seeds and id collisions, but be aware of any scenario that might cause duplicate MACs or host names in your environment.
+
 ```javascript
 
 // reading the MAC address is async, hence the ready call.

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,15 +1,11 @@
-var gulp = require( 'gulp' ),
-	mocha = require( 'gulp-mocha' );
+var gulp = require( 'gulp' );
+var bg = require( 'biggulp' )( gulp );
 
-gulp.task( 'test', function() {
-	gulp.src( './spec/*.spec.js' )
-		.pipe( mocha( { reporter: 'spec' } ) )
-		.on( 'error', function( err ) { console.log( err.message ); } );
-} );
+gulp.task( 'test', bg.withCoverage() );
 
 gulp.task( 'watch', function() {
-	gulp.watch( [ './src/**', './spec/**' ], [ 'test' ] );
+	bg.watch( [ 'test' ] );
 } );
 
-gulp.task( 'default', [ 'test', 'watch' ], function() {
-} );
+gulp.task( 'show-coverage', bg.showCoverage() );
+gulp.task( 'default', [ 'test', 'watch' ], function() {} );

--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
   ],
   "devDependencies": {
     "biggulp": "~0.0.2",
-    "gulp": "~3.8.11"
+    "gulp": "~3.8.11",
+    "should": "^5.2.0"
   },
   "dependencies": {
     "lodash": "~2.4.1",

--- a/package.json
+++ b/package.json
@@ -1,23 +1,34 @@
 {
   "name": "sliver",
-  "version": "0.0.5",
+  "version": "0.1.0",
   "description": "128-bit, k-ordered, lexicographically sortable, base 62, coordination free id generation for Node",
   "main": "src/sliver.js",
   "scripts": {
     "test": "gulp test"
   },
   "author": "Alex Robson",
-  
+  "publishConfig": {
+    "registry": "https://registry.npmjs.org/"
+  },
   "license": "MIT License - http://opensource.org/licenses/MIT",
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/LeanKit-Labs/sliver"
+  },
+  "keywords": [
+    "base 62",
+    "base 36",
+    "128 bit",
+    "flake"
+  ],
   "devDependencies": {
-    "should": "~3.2.0-beta1",
-    "gulp-mocha": "~0.4.1",
-    "gulp": "~3.5.6"
+    "biggulp": "~0.0.2",
+    "gulp": "~3.8.11"
   },
   "dependencies": {
     "lodash": "~2.4.1",
     "getmac": "~1.0.6",
     "murmurhash3": "~0.2.3",
-    "basejump": "~0.0.1"
+    "basejump": "~0.1.1"
   }
 }

--- a/spec/sliver.spec.js
+++ b/spec/sliver.spec.js
@@ -29,11 +29,7 @@ describe( 'when starting up without a seed', function() {
 	describe( 'when getting an id', function() {
 		var id;
 		before( function() {
-			var start = process.hrtime();
 			id = sliver.getId();
-			var diff = process.hrtime( start );
-			console.log( id );
-			console.log( ( diff[ 0 ] * 1e9 + diff[ 1 ] ) / 1000000 );
 		} );
 
 		it( 'should get a valid id', function() {
@@ -41,16 +37,16 @@ describe( 'when starting up without a seed', function() {
 		} );
 	} );
 
-	describe( 'when getting a bunch of ids', function() {
-		var diff,
-			list = [],
-			idCount = 10000;
-		this.timeout( 100000000 );
+	describe( 'when getting 10,000 ids', function() {
+		var diff;
+		var list = [];
+		var idCount = 10000;
+		this.timeout( 10000 );
 		before( function( done ) {
 			var start = process.hrtime();
-			for( i = 0; i < idCount; i++ ) {
-				list.push( sliver.getId() );	
-				if( list.length == idCount ) {
+			for (i = 0; i < idCount; i++) {
+				list.push( sliver.getId() );
+				if ( list.length == idCount ) {
 					diff = process.hrtime( start );
 					diff = ( diff[ 0 ] * 1e9 + diff[ 1 ] ) / 1000000;
 					done();
@@ -58,14 +54,14 @@ describe( 'when starting up without a seed', function() {
 			}
 		} );
 
-		it( 'should get a valid id', function() {
-			console.log( list.slice( 0, 20 ) );
-			console.log( diff );
-			console.log( _.unique( list ).length );
-			diff.should.be.lessThan( idCount / 5 );
+		it( 'should produce only unique ids', function() {
 			_.unique( list ).length.should.equal( idCount );
 		} );
-	} ); 
+
+		it( 'should average 15 ids/ms', function() {
+			( idCount / diff ).should.be.greaterThan( 15 );
+		} );
+	} );
 } );
 
 describe( 'when starting with a seed', function() {
@@ -76,7 +72,7 @@ describe( 'when starting with a seed', function() {
 		sliver = require( '../src/sliver.js' )( 'burple', done );
 	} );
 
-	it( 'should seed from seed value Address', function() {
+	it( 'should seed from seed value', function() {
 		sliver.seed.length.should.equal( 6 );
 	} );
 

--- a/src/sliver.js
+++ b/src/sliver.js
@@ -1,56 +1,45 @@
-var _ = require( 'lodash' ),
-	getMac = require( 'getmac' ).getMac,
-	jump = require( 'basejump' ),
-	murmur = require( 'murmurhash3' );
+var _ = require( 'lodash' );
+var getMac = require( 'getmac' ).getMac;
+var jump = require( 'basejump' );
+var murmur = require( 'murmurhash3' );
+var generator;
+var instanceCount = 0;
 
 // 128 bit ids can generate up to
 //          1    1    2    2    3    3   3
 //     5    0    5    0    5    0    5   9
 // 340282366920938463463374607431768211456
 // unique ids.
-// By base-62 encoding them, we can shorten the length of id to 22 places
-
-// via http://stackoverflow.com/questions/10253601/converting-large-integer-to-8-byte-array-in-javascript
-function bytesFromHex(str,pad){
-  if (str.length%2) str="0"+str;
-  var bytes = str.match(/../g).map(function(s){
-    return parseInt(s,16);
-  });
-  if (pad) for (var i=bytes.length;i<pad;++i) bytes.unshift(0);
-  return bytes;
-};
+// By base-62 encoding them, we can shorten the length of the id to 22 places
 
 // via http://stackoverflow.com/questions/8482309/converting-javascript-integer-to-byte-array-and-back
-function longToBytes(long) {
-    // we want to represent the input as a 8-bytes array
-    var byteArray = [0, 0, 0, 0, 0, 0, 0, 0];
-    for ( var index = 0; index < byteArray.length; index ++ ) {
-        var byte = long & 0xff;
-        byteArray [ index ] = byte;
-        long = ( (long - byte) / 256 );
-    }
-    return byteArray.reverse();
-};
+function longToBytes( long ) {
+	// we want to represent the input as a 8-bytes array
+	var byteArray = [ 0, 0, 0, 0, 0, 0, 0, 0 ];
+	for (var index = 0; index < byteArray.length; index++) {
+		var byte = long & 0xff;
+		byteArray [ index ] = byte;
+		long = ( ( long - byte ) / 256 );
+	}
+	return byteArray.reverse();
+}
 
-function getNodeBytesFromMac( done ) {
+function getWorkerIdFromEnvironment( done ) {
 	getMac( function( err, address ) {
-		if( err ) {
-			var bytes = getNodeBytesFromSeed( OS.hostname() );
-			done( bytes );
-		} else {
-			var bytes = bytesFromHex( address.split( /[:-]/ ).join( '' ) );
-			done( bytes );
+		var bytes, id;
+		if ( err ) {
+			address = os.hostname();
 		}
+		bytes = getNodeBytesFromSeed( address );
+		done( bytes );
 	} );
-};
+}
 
 function getNodeBytesFromSeed( seed ) {
-	var murm = murmur.murmur32Sync( seed.toString() );
+	var murm = murmur.murmur32Sync( [ seed.toString(), process.pid ].join( '|' ) );
 	bytes = longToBytes( murm ).splice( 2 );
 	return bytes;
-};
-
-var instanceCount = 0;
+}
 
 var Sliver = function( seed, ready ) {
 	ready = ready || function() {};
@@ -59,12 +48,10 @@ var Sliver = function( seed, ready ) {
 	this.seed = seed;
 	this.msBytes = [ 0, 0 ];
 	this.index = ++instanceCount;
-	if( !seed ) {
-		getMac( function( err, mac ) {
-			getNodeBytesFromMac( function( bytes ) {
-				this.seed = bytes;
-				ready();
-			}.bind( this ) );
+	if ( !seed ) {
+		getWorkerIdFromEnvironment( function( bytes ) {
+			this.seed = bytes;
+			ready();
 		}.bind( this ) );
 	} else {
 		this.seed = getNodeBytesFromSeed( seed );
@@ -75,16 +62,15 @@ var Sliver = function( seed, ready ) {
 Sliver.prototype.getId = function() {
 	this.updateTime();
 	var bytes = this.timestamp.concat( this.seed, this.msBytes ).reverse();
-	return jump.toBase62( bytes );
+	return jump.toBase62( bytes, 22 );
 };
 
 Sliver.prototype.updateTime = function() {
 	var now = Date.now();
 	var change = false;
-	if( now < this.lastMs ) {
-		throw 'Everything you know is a lie; NTP just jumped in space-time!';
-	}
-	else if( now > this.lastMs ) {
+	if ( now < this.lastMs ) {
+		throw new Error( 'Everything you know is a lie; NTP just jumped in space-time!' );
+	} else if ( now > this.lastMs ) {
 		change = true;
 		this.msCounter = 0;
 		this.msBytes = [ 0, 0 ];
@@ -97,14 +83,12 @@ Sliver.prototype.updateTime = function() {
 	return change;
 };
 
-var generator;
-
 module.exports = function( seed, ready ) {
-	if( _.isFunction( seed ) ) {
+	if ( _.isFunction( seed ) ) {
 		ready = seed;
 		seed = undefined;
 	}
-	if( generator && ready ) {
+	if ( generator && ready ) {
 		ready();
 	} else {
 		generator = new Sliver( seed, ready );


### PR DESCRIPTION
- Update to basejump version that supports Node versions v0.10.\* and v0.12.*
- Update to use MAC or Machine and PID as default worker id to ensure uniqueness
- Update tests, README, CHANGELOG and add License file
